### PR TITLE
feat: user can specify version for machine account domain

### DIFF
--- a/packages/msf/peaq_msf/machine_station.py
+++ b/packages/msf/peaq_msf/machine_station.py
@@ -903,7 +903,8 @@ class MachineStation(Base):
     async def machine_sign_machine_transaction(
         self,   
         options: MachineSignMachineTransactionOptions,
-        machine_owner_signer: Optional[BaseAccount] = None
+        machine_owner_signer: Optional[BaseAccount] = None,
+        version: str = "2"
     ) -> Union[str, EIP712SignableMessage]:
         """
         Creates a signable EIP-712 message for machine transaction execution.
@@ -927,7 +928,7 @@ class MachineStation(Base):
             calldata = ops.calldata
             nonce = ops.nonce
             
-            domain = await self._get_machine_account_domain("MachineSmartAccount", machine_address)
+            domain = await self._get_machine_account_domain("MachineSmartAccount", machine_address, version)
             types = {
                 "Execute": [
                     {"name": "target", "type": "address"},
@@ -1032,7 +1033,7 @@ class MachineStation(Base):
             "verifyingContract": self.machine_station_address
         }
 
-    async def _get_machine_account_domain(self, name: str, verifying_contract: str) -> dict:
+    async def _get_machine_account_domain(self, name: str, verifying_contract: str, version: str = "2") -> dict:
         """
         Generates an EIP-712 domain for MachineSmartAccount contract.
         
@@ -1045,7 +1046,7 @@ class MachineStation(Base):
         """
         return {
             "name": name,
-            "version": "2",
+            "version": version,
             "chainId": await self.get_chain_id(),
             "verifyingContract": verifying_contract
         }

--- a/packages/msf/peaq_msf/main.py
+++ b/packages/msf/peaq_msf/main.py
@@ -400,7 +400,8 @@ class Main(Base):
     async def machine_sign_machine_transaction(
         self,
         options: MachineSignMachineTransactionOptions,
-        machine_owner_signer: Optional[BaseAccount] = None
+        machine_owner_signer: Optional[BaseAccount] = None,
+        version: str = "2"
     ) -> Union[str, EIP712SignableMessage]:
         """
         Creates a signable EIP-712 message for machine transaction execution.
@@ -414,7 +415,7 @@ class Main(Base):
         Returns:
             Either the signature string or EIP-712 signable message object
         """
-        return await self._machine_station.machine_sign_machine_transaction(options, machine_owner_signer)
+        return await self._machine_station.machine_sign_machine_transaction(options, machine_owner_signer, version)
 
     async def machine_sign_transfer_machine_balance(
         self,


### PR DESCRIPTION
Allow the user to be able to set which version they would like to use when obtaining the _get_machine_account_domain() to assist in migration from v1 smart accounts to v2